### PR TITLE
remove jekyll-admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
   gem "jekyll-gist"
   gem "jekyll-sitemap"
-  gem 'jekyll-admin'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/_config.yml
+++ b/_config.yml
@@ -57,10 +57,3 @@ owner:
     ad-client:
     ad-slot:
   bing-verify:
-
-jekyll_admin:
-  hidden_links:
-    - pages
-    - staticfiles
-    - datafiles
-    - configuration


### PR DESCRIPTION
Removed as admin not usable on Github